### PR TITLE
use requests.Session for connection reuse

### DIFF
--- a/shodan/client.py
+++ b/shodan/client.py
@@ -129,7 +129,8 @@ class Shodan:
         self.labs = self.Labs(self)
         self.tools = self.Tools(self)
         self.stream = Stream(key)
-    
+        self._session = requests.Session()
+            
     def _request(self, function, params, service='shodan', method='get'):
         """General-purpose function to create web requests to SHODAN.
         
@@ -153,9 +154,9 @@ class Shodan:
         # Send the request
         try:
             if method.lower() == 'post':
-                data = requests.post(base_url + function, params)
+                data = self._session.post(base_url + function, params)
             else:
-                data = requests.get(base_url + function, params=params)
+                data = self._session.get(base_url + function, params=params)
         except:
             raise APIError('Unable to connect to Shodan')
 


### PR DESCRIPTION
The current version opens a new connection for each API request even though the server supports HTTP keep-alive and thus many requests could be made using the same connection.
This patch uses requests.Session to allow connection reuse. This shaves something like 400 ms from each subsequent request because there is no need to open a new connection. For people doing many requests in short succession this can lead to significant speed up (about 2x the speed for my case of doing many host requests).