### PR TITLE
stream: automatically decode to unicode

### DIFF
--- a/shodan/stream.py
+++ b/shodan/stream.py
@@ -31,10 +31,12 @@ class Stream:
             except Exception as e:
                 pass
             raise APIError('Invalid API key or you do not have access to the Streaming API')
+        if req.encoding is None:
+            req.encoding = 'utf-8'
         return req
 
     def _iter_stream(self, stream, raw):
-        for line in stream.iter_lines():
+        for line in stream.iter_lines(decode_unicode=True):
             if line:
                 if raw:
                     yield line


### PR DESCRIPTION
fixes streaming on python3

See https://requests.readthedocs.io/en/master/user/advanced/#streaming-requests