### PR TITLE
StandardError was removed in Python 3

### DIFF
--- a/shodan/cli/worldmap.py
+++ b/shodan/cli/worldmap.py
@@ -177,7 +177,7 @@ class AsciiMap(object):
                     self.window.addstr(row, 1, det_show, attrs)
                     row += 1
                     items_to_show -= 1
-                except StandardError:
+                except Exeception:
                     # FIXME: check window size before addstr()
                     break
         self.window.overwrite(target)


### PR DESCRIPTION
Use Exception instead.