### PR TITLE
Undefined name: Don't forget self when calling flatten()

### DIFF
--- a/shodan/cli/converter/csvc.py
+++ b/shodan/cli/converter/csvc.py
@@ -81,7 +81,6 @@ class CsvConverter(Converter):
         for k, v in d.items():
             new_key = parent_key + sep + k if parent_key else k
             if isinstance(v, MutableMapping):
-                # pylint: disable=E0602
                 items.extend(self.flatten(v, new_key, sep=sep).items())
             else:
                 items.append((new_key, v))

--- a/shodan/cli/converter/csvc.py
+++ b/shodan/cli/converter/csvc.py
@@ -82,7 +82,7 @@ class CsvConverter(Converter):
             new_key = parent_key + sep + k if parent_key else k
             if isinstance(v, MutableMapping):
                 # pylint: disable=E0602
-                items.extend(flatten(v, new_key, sep=sep).items())
+                items.extend(self.flatten(v, new_key, sep=sep).items())
             else:
                 items.append((new_key, v))
         return dict(items)


### PR DESCRIPTION
PyLint is complaining because __flatten__ is an undefined name in this context which has the potential to raise NameError at runtime.  __self.flatten()__ makes more sense here.

An alternative approach would be to use:
```python
@staticmethod
def flatten(d, parent_key='', sep='.'):
```

[flake8](http://flake8.pycqa.org) testing of https://github.com/achillean/shodan-python on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./shodan/cli/helpers.py:73:52: F821 undefined name 'basestring'
        if field_type == list or isinstance(value, basestring):
                                                   ^
./shodan/cli/worldmap.py:180:24: F821 undefined name 'StandardError'
                except StandardError:
                       ^
./shodan/cli/converter/csvc.py:85:30: F821 undefined name 'flatten'
                items.extend(flatten(v, new_key, sep=sep).items())
                             ^
3     F821 undefined name 'flatten'
3
```