### PR TITLE
Undefined name: 'basestring' was removed in Python 3

### DIFF
--- a/shodan/cli/helpers.py
+++ b/shodan/cli/helpers.py
@@ -10,6 +10,11 @@ import sys
 
 from .settings import SHODAN_CONFIG_DIR
 
+try:
+    basestring            # Python 2
+except NameError:
+    basestring = (str, )  # Python 3
+
 def get_api_key():
     '''Returns the API key of the current logged-in user.'''
     shodan_dir = os.path.expanduser(SHODAN_CONFIG_DIR)


### PR DESCRIPTION
__basestring__ was removed in Python 3 but it is used on line 78 without being defined.