### PR TITLE
Add exception raised when retry limit reached (#94)

### DIFF
--- a/shodan/client.py
+++ b/shodan/client.py
@@ -431,7 +431,7 @@ class Shodan:
         :param minify: (optional) Whether to minify the banner and only return the important data
         :type minify: bool
         :param retries: (optional) How often to retry the search in case it times out
-        :type minify: int
+        :type retries: int
 
         :returns: A search cursor that can be used as an iterator/ generator.
         """
@@ -454,7 +454,7 @@ class Shodan:
             except Exception:
                 # We've retried several times but it keeps failing, so lets error out
                 if tries >= retries:
-                    break
+                    raise APIError('Retry limit reached ({:d})'.format(retries))
 
                 tries += 1
                 time.sleep(1.0)  # wait 1 second if the search errored out for some reason


### PR DESCRIPTION
Fix [issue 94](https://github.com/achillean/shodan-python/issues/94).

The `download`command in CLI, using `search_cursor`, [catches any exceptions](https://github.com/achillean/shodan-python/blob/master/shodan/__main__.py#L236) so this one will also be silently. I don't know the wanted behavior in this case, if the command must raise a `click.Exception` or not.