### PR TITLE
Add "net:ip/mask" filter for shodan parse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ click-plugins
 colorama
 requests>=2.2.1
 XlsxWriter
+ipaddress;python_version<='2.7'

--- a/shodan/cli/helpers.py
+++ b/shodan/cli/helpers.py
@@ -7,6 +7,7 @@ import gzip
 import itertools
 import os
 import sys
+from ipaddress import ip_network, ip_address
 
 from .settings import SHODAN_CONFIG_DIR
 
@@ -69,7 +70,6 @@ def filter_with_netmask(banner, netmask):
     # a mere check for a specific field and thus needs its own mechanism
     # this will enable users to use the net:10.0.0.0/8 syntax they are used to
     # to find specific networks from a big shodan download.
-    from ipaddress import ip_network, ip_address
     network = ip_network(netmask)
     ip_field = get_banner_field(banner, 'ip')
     if not ip_field:

--- a/shodan/cli/helpers.py
+++ b/shodan/cli/helpers.py
@@ -64,9 +64,26 @@ def get_banner_field(banner, flat_field):
     return None
 
 
+def filter_with_netmask(banner, netmask):
+    # filtering based on netmask is a more abstract concept than
+    # a mere check for a specific field and thus needs its own mechanism
+    # this will enable users to use the net:10.0.0.0/8 syntax they are used to
+    # to find specific networks from a big shodan download.
+    from ipaddress import ip_network, ip_address
+    network = ip_network(netmask)
+    ip_field = get_banner_field(banner, 'ip')
+    if not ip_field:
+        return False
+    banner_ip_address = ip_address(ip_field)
+    return banner_ip_address in network
+
+
 def match_filters(banner, filters):
     for args in filters:
         flat_field, check = args.split(':', 1)
+        if flat_field == 'net':
+            return filter_with_netmask(banner, check)
+
         value = get_banner_field(banner, flat_field)
 
         # If the field doesn't exist on the banner then ignore the record


### PR DESCRIPTION
A simple implementation of the net:filter used in web GUI.

It uses python3's builtin ipaddress lib and only imports those libs if the net:filter is used.

Example:
```bash
$ shodan download example 'country:fi cyber'
```
```bash
$ shodan parse example.json.gz  | cut -c1-100
95.216.39.52	53	srv01.cyber-cortex.net	PowerDNS Authoritative Server 4.1.1\nResolver ID: srv01.cyber
95.216.52.222	2083	static.222.52.216.95.clients.your-server.de	HTTP/1.1 200 OK\r\nDate: Sun, 15 Sep 

$ shodan parse -f net:95.216.39.0/24 example.json.gz  | cut -c1-100
95.216.39.52	53	srv01.cyber-cortex.net	PowerDNS Authoritative Server 4.1.1\nResolver ID: srv01.cyber

$ shodan parse -f net:95.216.0.0/16 example.json.gz  | cut -c1-100
95.216.39.52	53	srv01.cyber-cortex.net	PowerDNS Authoritative Server 4.1.1\nResolver ID: srv01.cyber
95.216.52.222	2083	static.222.52.216.95.clients.your-server.de	HTTP/1.1 200 OK\r\nDate: Sun, 15 Sep 
```