### PR TITLE
Add timeout to requests in Shodan._request()

### DIFF
--- a/shodan/cli/settings.py
+++ b/shodan/cli/settings.py
@@ -8,3 +8,4 @@ COLORIZE_FIELDS = {
     'org': 'cyan',
     'vulns': 'red',
 }
+REQUESTS_TIMEOUT = (30, 30)  # (connect, read)

--- a/shodan/client.py
+++ b/shodan/client.py
@@ -15,6 +15,7 @@ import json
 from .exception import APIError
 from .helpers import api_request, create_facet_string
 from .stream import Stream
+from .cli.settings import REQUESTS_TIMEOUT
 
 
 # Try to disable the SSL warnings in urllib3 since not everybody can install
@@ -294,13 +295,13 @@ class Shodan:
         try:
             method = method.lower()
             if method == 'post':
-                data = self._session.post(base_url + function, params)
+                data = self._session.post(base_url + function, params, timeout=REQUESTS_TIMEOUT)
             elif method == 'put':
-                data = self._session.put(base_url + function, params=params)
+                data = self._session.put(base_url + function, params=params, timeout=REQUESTS_TIMEOUT)
             elif method == 'delete':
-                data = self._session.delete(base_url + function, params=params)
+                data = self._session.delete(base_url + function, params=params, timeout=REQUESTS_TIMEOUT)
             else:
-                data = self._session.get(base_url + function, params=params)
+                data = self._session.get(base_url + function, params=params, timeout=REQUESTS_TIMEOUT)
         except Exception:
             raise APIError('Unable to connect to Shodan')
 


### PR DESCRIPTION
I've noticed that when facing network problems (e.g. Wi-Fi connection dropped) Shodan may hang indefinitely without timing out. The code calling the Shodan library has no control over this and may be left hanging for a response.

According to the [`requests` documentation](requests_timeout) requests should have a timeout:

> Most requests to external servers should have a timeout attached, in case the server is not responding in a timely manner. By default, requests do not time out unless a timeout value is set explicitly. Without a timeout, your code may hang for minutes or more.

These changes define a `REQUESTS_TIMEOUT` constant which defines a **connect** and **read** timeout of 30 seconds each. These timeouts are applied to the `_request()` method of the `Shodan` class.


[requests_timeouts]: https://3.python-requests.org/user/advanced/#timeouts