### PR TITLE
move config dir to ~/.config

### DIFF
--- a/shodan/__main__.py
+++ b/shodan/__main__.py
@@ -210,7 +210,7 @@ def init(key):
     shodan_dir = os.path.expanduser(SHODAN_CONFIG_DIR)
     if not os.path.isdir(shodan_dir):
         try:
-            os.mkdir(shodan_dir)
+            os.makedirs(shodan_dir)
         except OSError:
             raise click.ClickException('Unable to create directory to store the Shodan API key ({})'.format(shodan_dir))
 

--- a/shodan/cli/settings.py
+++ b/shodan/cli/settings.py
@@ -1,10 +1,5 @@
-from os import path
 
-if path.exists(path.expanduser("~/.config/shodan")):
-    SHODAN_CONFIG_DIR="~/.config/shodan/"
-else:
-    SHODAN_CONFIG_DIR = '~/.shodan/'
-
+SHODAN_CONFIG_DIR = '~/.shodan/'
 COLORIZE_FIELDS = {
     'ip_str': 'green',
     'port': 'yellow',

--- a/shodan/cli/settings.py
+++ b/shodan/cli/settings.py
@@ -1,5 +1,10 @@
+from os import path
 
-SHODAN_CONFIG_DIR = '~/.shodan/'
+if path.exists(path.expanduser("~/.config/shodan")):
+    SHODAN_CONFIG_DIR="~/.config/shodan/"
+else:
+    SHODAN_CONFIG_DIR = '~/.shodan/'
+
 COLORIZE_FIELDS = {
     'ip_str': 'green',
     'port': 'yellow',

--- a/shodan/cli/settings.py
+++ b/shodan/cli/settings.py
@@ -1,5 +1,11 @@
 
-SHODAN_CONFIG_DIR = '~/.shodan/'
+from os import path
+
+if path.exists(path.expanduser("~/.shodan")):
+    SHODAN_CONFIG_DIR = '~/.shodan/'
+else:
+    SHODAN_CONFIG_DIR="~/.config/shodan/"
+
 COLORIZE_FIELDS = {
     'ip_str': 'green',
     'port': 'yellow',


### PR DESCRIPTION
In reference to #135 
I hope this fix is ok with you guys. I notice you didn't have any logic code in settings.py, but I feel as though this is the easiest way to implement this. This method allows users who create the `~/.config/shodan` directory to utilise it, while still providing support for the users who do not care to move the folder. 

I also ran `tox` and got 
```
python: commands succeeded
  congratulations :)
```
Not sure if that's how to run the tests