### PR TITLE
Add API Rate Limiting to Shodan Class

### DIFF
--- a/shodan/__main__.py
+++ b/shodan/__main__.py
@@ -288,10 +288,10 @@ def download(limit, skip, filename, query):
         raise click.ClickException('The Shodan API is unresponsive at the moment, please try again later.')
 
     # Print some summary information about the download request
-    click.echo('Search query:\t\t\t%s' % query)
-    click.echo('Total number of results:\t%s' % total)
-    click.echo('Query credits left:\t\t%s' % info['unlocked_left'])
-    click.echo('Output file:\t\t\t%s' % filename)
+    click.echo('Search query:\t\t\t{}'.format(query))
+    click.echo('Total number of results:\t{}'.format(total))
+    click.echo('Query credits left:\t\t{}'.format(info['unlocked_left']))
+    click.echo('Output file:\t\t\t{}'.format(filename))
 
     if limit > total:
         limit = total

--- a/shodan/cli/helpers.py
+++ b/shodan/cli/helpers.py
@@ -47,7 +47,7 @@ def timestr():
 
 
 def open_streaming_file(directory, timestr, compresslevel=9):
-    return gzip.open('%s/%s.json.gz' % (directory, timestr), 'a', compresslevel)
+    return gzip.open('{}/{}.json.gz'.format(directory, timestr), 'a', compresslevel)
 
 
 def get_banner_field(banner, flat_field):

--- a/shodan/cli/settings.py
+++ b/shodan/cli/settings.py
@@ -4,7 +4,7 @@ from os import path
 if path.exists(path.expanduser("~/.shodan")):
     SHODAN_CONFIG_DIR = '~/.shodan/'
 else:
-    SHODAN_CONFIG_DIR="~/.config/shodan/"
+    SHODAN_CONFIG_DIR = "~/.config/shodan/"
 
 COLORIZE_FIELDS = {
     'ip_str': 'green',

--- a/shodan/cli/worldmap.py
+++ b/shodan/cli/worldmap.py
@@ -166,7 +166,7 @@ class AsciiMap(object):
                 attrs |= curses.color_pair(self.colors[color])
             self.window.addstr(char_y, char_x, char, attrs)
             if desc:
-                det_show = "%s %s" % (char, desc)
+                det_show = "{} {}".format(char, desc)
             else:
                 det_show = None
 
@@ -179,7 +179,7 @@ class AsciiMap(object):
                     # FIXME: check window size before addstr()
                     break
         self.window.overwrite(target)
-        self.window.leaveok(1)
+        self.window.leaveok(True)
 
 
 class MapApp(object):

--- a/shodan/client.py
+++ b/shodan/client.py
@@ -273,6 +273,8 @@ class Shodan:
         self.tools = self.Tools(self)
         self.stream = Stream(key, proxies=proxies)
         self._session = requests.Session()
+        self.api_rate_limit = 1  # Requests per second
+        self._api_query_time = None
         if proxies:
             self._session.proxies.update(proxies)
             self._session.trust_env = False
@@ -297,6 +299,11 @@ class Shodan:
             'exploits': self.base_exploits_url,
         }.get(service, 'shodan')
 
+        # Wait for API rate limit
+        if self._api_query_time is not None and self.api_rate_limit > 0:
+            while (1.0 / self.api_rate_limit) + self._api_query_time >= time.time():
+                time.sleep(0.1 / self.api_rate_limit)
+
         # Send the request
         try:
             method = method.lower()
@@ -308,6 +315,7 @@ class Shodan:
                 data = self._session.delete(base_url + function, params=params)
             else:
                 data = self._session.get(base_url + function, params=params)
+            self._api_query_time = time.time()
         except Exception:
             raise APIError('Unable to connect to Shodan')
 
@@ -377,7 +385,7 @@ class Shodan:
             params['history'] = history
         if minify:
             params['minify'] = minify
-        return self._request('/shodan/host/%s' % ','.join(ips), params)
+        return self._request('/shodan/host/{}'.format(','.join(ips)), params)
 
     def info(self):
         """Returns information about the current API key, such as a list of add-ons
@@ -468,7 +476,7 @@ class Shodan:
 
         :returns: A dictionary with general information about the scan, including its status in getting processed.
         """
-        return self._request('/shodan/scan/%s' % scan_id, {})
+        return self._request('/shodan/scan/{}'.format(scan_id), {})
 
     def search(self, query, page=1, limit=None, offset=None, facets=None, minify=True):
         """Search the SHODAN database.
@@ -685,7 +693,7 @@ class Shodan:
     def alerts(self, aid=None, include_expired=True):
         """List all of the active alerts that the user created."""
         if aid:
-            func = '/shodan/alert/%s/info' % aid
+            func = '/shodan/alert/{}/info'.format(aid)
         else:
             func = '/shodan/alert/info'
 
@@ -697,7 +705,7 @@ class Shodan:
 
     def delete_alert(self, aid):
         """Delete the alert with the given ID."""
-        func = '/shodan/alert/%s' % aid
+        func = '/shodan/alert/{}'.format(aid)
 
         response = api_request(self.api_key, func, params={}, method='delete',
                                proxies=self._session.proxies)

--- a/shodan/helpers.py
+++ b/shodan/helpers.py
@@ -142,7 +142,7 @@ def write_banner(fout, banner):
     fout.write(line.encode('utf-8'))
 
 
-def humanize_bytes(bytes, precision=1):
+def humanize_bytes(byte_count, precision=1):
     """Return a humanized string representation of a number of bytes.
     >>> humanize_bytes(1)
     '1 byte'
@@ -161,15 +161,15 @@ def humanize_bytes(bytes, precision=1):
     >>> humanize_bytes(1024*1234*1111,1)
     '1.3 GB'
     """
-    if bytes == 1:
+    if byte_count == 1:
         return '1 byte'
-    if bytes < 1024:
-        return '%.*f %s' % (precision, bytes, "bytes")
+    if byte_count < 1024:
+        '{0:0.{1}f} {2}'.format(byte_count, 0, 'bytes')
 
     suffixes = ['KB', 'MB', 'GB', 'TB', 'PB']
     multiple = 1024.0  # .0 to force float on python 2
     for suffix in suffixes:
-        bytes /= multiple
-        if bytes < multiple:
-            return '%.*f %s' % (precision, bytes, suffix)
-    return '%.*f %s' % (precision, bytes, suffix)
+        byte_count /= multiple
+        if byte_count < multiple:
+            return '{0:0.{1}f} {2}'.format(byte_count, precision, suffix)
+    return '{0:0.{1}f} {2}'.format(byte_count, precision, suffix)

--- a/shodan/stream.py
+++ b/shodan/stream.py
@@ -71,7 +71,7 @@ class Stream:
 
     def alert(self, aid=None, timeout=None, raw=False):
         if aid:
-            stream = self._create_stream('/shodan/alert/%s' % aid, timeout=timeout)
+            stream = self._create_stream('/shodan/alert/{}'.format(aid), timeout=timeout)
         else:
             stream = self._create_stream('/shodan/alert', timeout=timeout)
 
@@ -90,7 +90,7 @@ class Stream:
         :param asn: A list of ASN to return banner data on.
         :type asn: string[]
         """
-        stream = self._create_stream('/shodan/asn/%s' % ','.join(asn), timeout=timeout)
+        stream = self._create_stream('/shodan/asn/{}'.format(','.join(asn)), timeout=timeout)
         for line in self._iter_stream(stream, raw):
             yield line
 
@@ -109,7 +109,7 @@ class Stream:
         :param countries: A list of countries to return banner data on.
         :type countries: string[]
         """
-        stream = self._create_stream('/shodan/countries/%s' % ','.join(countries), timeout=timeout)
+        stream = self._create_stream('/shodan/countries/{}'.format(','.join(countries)), timeout=timeout)
         for line in self._iter_stream(stream, raw):
             yield line
 
@@ -120,7 +120,7 @@ class Stream:
         :param ports: A list of ports to return banner data on.
         :type ports: int[]
         """
-        stream = self._create_stream('/shodan/ports/%s' % ','.join([str(port) for port in ports]), timeout=timeout)
+        stream = self._create_stream('/shodan/ports/{}'.format(','.join([str(port) for port in ports])), timeout=timeout)
         for line in self._iter_stream(stream, raw):
             yield line
 
@@ -131,7 +131,7 @@ class Stream:
         :param tags: A list of tags to return banner data on.
         :type tags: string[]
         """
-        stream = self._create_stream('/shodan/tags/%s' % ','.join(tags), timeout=timeout)
+        stream = self._create_stream('/shodan/tags/{}'.format(','.join(tags)), timeout=timeout)
         for line in self._iter_stream(stream, raw):
             yield line
 
@@ -142,6 +142,6 @@ class Stream:
         :param vulns: A list of vulns to return banner data on.
         :type vulns: string[]
         """
-        stream = self._create_stream('/shodan/vulns/%s' % ','.join(vulns), timeout=timeout)
+        stream = self._create_stream('/shodan/vulns/{}'.format(','.join(vulns)), timeout=timeout)
         for line in self._iter_stream(stream, raw):
             yield line


### PR DESCRIPTION
This pull adds API rate limits to the Shodan class, with a default of 1 query per second per class.
It also includes minor changes:
 - Convert residual % formatting to use str.format() like formats used in most of the project
 - Fix human precision of bytes under 1024 to always use 0