### PR TITLE
Add input validation to shodan convert command

### DIFF
--- a/shodan/__main__.py
+++ b/shodan/__main__.py
@@ -37,7 +37,7 @@ import threading
 import requests
 import time
 import json
-from shodan.cli.validation import check_file_format, check_input_file_type
+from shodan.cli.validation import check_input_file_type
 
 # The file converters that are used to go from .json.gz to various other formats
 from shodan.cli.converter import CsvConverter, KmlConverter, GeoJsonConverter, ExcelConverter, ImagesConverter

--- a/shodan/__main__.py
+++ b/shodan/__main__.py
@@ -95,7 +95,7 @@ main.add_command(scan)
 @main.command()
 @click.option('--fields', help='List of properties to output.', default=None)
 @click.argument('input', metavar='<input file>', type=click.Path(exists=True), callback=check_input_file_type)
-@click.argument('format', metavar='<output format>', type=click.Choice(CONVERTERS.keys()), callback=check_file_format)
+@click.argument('format', metavar='<output format>', type=click.Choice(CONVERTERS.keys()))
 def convert(fields, input, format):
     """Convert the given input data file into a different format. The following file formats are supported:
 

--- a/shodan/__main__.py
+++ b/shodan/__main__.py
@@ -37,6 +37,7 @@ import threading
 import requests
 import time
 import json
+from shodan.cli.validation import check_file_format, check_input_file_type
 
 # The file converters that are used to go from .json.gz to various other formats
 from shodan.cli.converter import CsvConverter, KmlConverter, GeoJsonConverter, ExcelConverter, ImagesConverter
@@ -93,8 +94,8 @@ main.add_command(scan)
 
 @main.command()
 @click.option('--fields', help='List of properties to output.', default=None)
-@click.argument('input', metavar='<input file>', type=click.Path(exists=True))
-@click.argument('format', metavar='<output format>', type=click.Choice(CONVERTERS.keys()))
+@click.argument('input', metavar='<input file>', type=click.Path(exists=True), callback=check_input_file_type)
+@click.argument('format', metavar='<output format>', type=click.Choice(CONVERTERS.keys()), callback=check_file_format)
 def convert(fields, input, format):
     """Convert the given input data file into a different format. The following file formats are supported:
 

--- a/shodan/cli/validation.py
+++ b/shodan/cli/validation.py
@@ -13,17 +13,3 @@ def check_input_file_type(ctx, param, value):
     if idx == -1 or value[idx:] != ".json.gz":
         raise click.BadParameter("Input file type must be '.json.gz'")
     return value
-
-def check_file_format(ctx, param, value):
-    """
-    Click callback method used for output file format input validation.
-    :param ctx: Python Click library Context object.
-    :param param: Python Click Context object params attribute.
-    :param value: Value passed in for a given command line parameter.
-    """
-    supported_file_types = ["kml", "csv", "geo.json", "images", "xlsx"]
-    file_type_str = ', '.join(supported_file_types)
-
-    if value not in supported_file_types:
-        raise click.BadParameter(f"Output file type must be one of the supported file extensions:\n{file_type_str}")
-    return value

--- a/shodan/cli/validation.py
+++ b/shodan/cli/validation.py
@@ -1,0 +1,29 @@
+import click
+
+
+def check_input_file_type(ctx, param, value):
+    """
+    Click callback method used for file type input validation.
+    :param ctx: Python Click library Context object.
+    :param param: Python Click Context object params attribute.
+    :param value: Value passed in for a given command line parameter.
+    """
+    idx = value.find(".")
+
+    if idx == -1 or value[idx:] != ".json.gz":
+        raise click.BadParameter("Input file type must be '.json.gz'")
+    return value
+
+def check_file_format(ctx, param, value):
+    """
+    Click callback method used for output file format input validation.
+    :param ctx: Python Click library Context object.
+    :param param: Python Click Context object params attribute.
+    :param value: Value passed in for a given command line parameter.
+    """
+    supported_file_types = ["kml", "csv", "geo.json", "images", "xlsx"]
+    file_type_str = ', '.join(supported_file_types)
+
+    if value not in supported_file_types:
+        raise click.BadParameter(f"Output file type must be one of the supported file extensions:\n{file_type_str}")
+    return value


### PR DESCRIPTION
- Closes out #204 
- Created **validation.py** where I stored 2 functions used as callback methods for the input file type and output format for the `shodan convert` command.
- Functions used for input validation are passed in via the **callback** parameter for click.argument.