### PR TITLE
APIError support for Status Code

### DIFF
--- a/shodan/client.py
+++ b/shodan/client.py
@@ -397,7 +397,7 @@ class Shodan:
             raise APIError('Unable to parse JSON response', data.status_code)
 
         # Raise an exception if an error occurred
-        if type(parsed_data) == dict and 'error' in parsed_data:
+        if isinstance(parsed_data, dict) and 'error' in parsed_data:
             raise APIError(parsed_data['error'], data.status_code)
 
         # Return the data

--- a/shodan/client.py
+++ b/shodan/client.py
@@ -384,24 +384,24 @@ class Shodan:
                     # Otherwise lets raise the error message
                     error = u'{}'.format(e)
 
-            raise APIError(error)
+            raise APIError(error, data.status_code)
         elif data.status_code == 403:
-            raise APIError('Access denied (403 Forbidden)')
+            raise APIError('Access denied (403 Forbidden)', data.status_code)
         elif data.status_code == 502:
-            raise APIError('Bad Gateway (502)')
+            raise APIError('Bad Gateway (502)', data.status_code)
 
         # Parse the text into JSON
         try:
-            data = data.json()
+            parsed_data = data.json()
         except ValueError:
-            raise APIError('Unable to parse JSON response')
+            raise APIError('Unable to parse JSON response', data.status_code)
 
         # Raise an exception if an error occurred
-        if type(data) == dict and 'error' in data:
-            raise APIError(data['error'])
+        if type(parsed_data) == dict and 'error' in parsed_data:
+            raise APIError(parsed_data['error'], data.status_code)
 
         # Return the data
-        return data
+        return parsed_data
 
     def count(self, query, facets=None):
         """Returns the total number of search results for the query.

--- a/shodan/exception.py
+++ b/shodan/exception.py
@@ -1,6 +1,7 @@
 class APIError(Exception):
     """This exception gets raised whenever a non-200 status code was returned by the Shodan API."""
-    def __init__(self, value, status_code=None):
+
+    def __init__(self, value, status_code=0):
         self.value = value
         self.status_code = status_code
 

--- a/shodan/exception.py
+++ b/shodan/exception.py
@@ -1,7 +1,8 @@
 class APIError(Exception):
     """This exception gets raised whenever a non-200 status code was returned by the Shodan API."""
-    def __init__(self, value):
+    def __init__(self, value, status_code=None):
         self.value = value
+        self.status_code = status_code
 
     def __str__(self):
         return self.value


### PR DESCRIPTION
Add the HTTP Status code to the APIError when it is appropiate. There are some APIError raised that are not really a HTTPError, so the `status_code` is None.
To support backwards compatibility, I added the `status_code` as optional with default of None so all existing users won't have any effect.
I also left the `__str__` unchanged, to also be backwards compatible. 